### PR TITLE
Fix MIPPS SVID parsing in Structured VDM ACK handling

### DIFF
--- a/lib/usb_pd/usbpd_sink.c
+++ b/lib/usb_pd/usbpd_sink.c
@@ -1280,21 +1280,36 @@ static void usbpd_sink_protocol_analysis_sop0(const uint8_t *rx_buffer, uint8_t 
                         }
                         // ACK
                         if (vdm_header.StructuredVDMHeader.CommandType == VDM_COMMAND_TYPE_ACK) {
-                            // 判断 SVID
-                            uint16_t svid = *(uint16_t *)&rx_buffer[8];
-                            pd_printf("  SVID: 0x%04x\n", svid);
-                            if (svid != 0x2717) {
-                                pd_printf("MIPPS: Unknown SVID 0x%04x, jumping to IDLE state\n", svid);
-                                // pd_control_g.pd_state = PD_STATE_IDLE;
-                                pd_control_g.pd_state = MIPPS_STATE_SEND_GET_SRC_CAP;
-                                break;
-                            }
-
                             if (vdm_header.StructuredVDMHeader.Command == VDM_COMMAND_DISCOVER_IDENTITY) {
+                                // Discover Identity ACK does not carry SVID list.
                                 pd_control_g.pd_state = MIPPS_STATE_SEND_VDM_REQ_DISCOVER_SVIDS;
                                 break;
                             }
+
                             if (vdm_header.StructuredVDMHeader.Command == VDM_COMMAND_DISCOVER_SVIDS) {
+                                // Parse SVIDs from VDO list (each VDO has two 16-bit SVIDs).
+                                uint8_t vdo_count = header.MessageHeader.NumberOfDataObjects > 0
+                                                        ? (uint8_t)(header.MessageHeader.NumberOfDataObjects - 1)
+                                                        : 0;
+                                bool svid_found = false;
+
+                                for (uint8_t i = 0; i < vdo_count; i++) {
+                                    uint32_t vdo = *(uint32_t *)&rx_buffer[6 + (i * 4)];
+                                    uint16_t svid0 = (uint16_t)(vdo & 0xFFFFu);
+                                    uint16_t svid1 = (uint16_t)((vdo >> 16) & 0xFFFFu);
+                                    pd_printf("  SVID[%d]: 0x%04x 0x%04x\n", i, svid0, svid1);
+
+                                    if (svid0 == 0x2717 || svid1 == 0x2717) {
+                                        svid_found = true;
+                                    }
+                                }
+
+                                if (!svid_found) {
+                                    pd_printf("MIPPS: SVID 0x2717 not found, jumping to IDLE state\n");
+                                    pd_control_g.pd_state = MIPPS_STATE_SEND_GET_SRC_CAP;
+                                    break;
+                                }
+
                                 pd_control_g.pd_state = MIPPS_STATE_SEND_VDM_1;
                                 break;
                             }


### PR DESCRIPTION
我在测试 Xiaomi 120W MDY-12-ED 充电器时收到错误 `MIPPS: Unknown SVID 0x0580, jumping to IDLE state` 且读取的 SVID 会随机跳动。我使用Copilot修复了相关问题并成功读取到MIPPS，但对问题成因不明且未测试能否激活输出。相关测试日志在 [https://gist.github.com/FibreCase/df55987b6506f599f5e2dc659644a69d](https://gist.github.com/FibreCase/df55987b6506f599f5e2dc659644a69d)。

以下是Copilot给出的信息：

**PR 描述**

**背景/问题**
- USB PD 的 Structured VDM ACK 处理里，代码在所有 ACK 中直接从 `rx_buffer[8]` 读取 SVID。
- 该偏移并不是 SVID 列表起点，且 `Discover Identity` ACK 本身不携带 SVID 列表，导致读到 VDO 的其它字段（例如 `0x05c0`），从而误判。

**根因**
- 解析时机错误：把 `Discover Identity` 与 `Discover SVIDs` 的 ACK 混合处理。
- 解析位置错误：SVID 列表应来自 VDO 列表，而非固定的 `rx_buffer[8]` 偏移。

**修复**
- 在 `Discover Identity` ACK 里仅触发下一步 `Discover SVIDs` 请求，不解析 SVID。
- 在 `Discover SVIDs` ACK 中解析 VDO 列表：从 `rx_buffer[6]` 起，每个 VDO 含两个 16 位 SVID，遍历查找目标 `0x2717`。

**影响**
- 避免把 ID Header 等非 SVID 字段误认为 SVID。
- 正确识别包含 `0x2717` 的充电器 SVID。

**验证**
- 观察日志输出的 SVID 列表应包含 `0x2717`，不再出现误判为 `0x05c0` 的情况。